### PR TITLE
Support cross-compiling & building as static lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.o
 /img4
+/libimg4.a

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.o
+/img4

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,14 @@ LD = gcc
 LDFLAGS = -g -Llzfse/build/bin
 LDLIBS = -llzfse
 
+LIBTOOL = libtool
+LIBTOOL_FLAGS = -static
+
 SOURCES = \
 	lzss.c \
 	img4.c
+
+LIBSOURCES = lzss.c
 
 VFSSOURCES = \
 	libvfs/vfs_file.c \
@@ -93,6 +98,7 @@ CCSOURCES = \
 	corecrypto/cczp_sqr.c
 
 OBJECTS = $(SOURCES:.c=.o) $(DERSOURCES:.c=.o) $(VFSSOURCES:.c=.o)
+LIBOBJECTS = $(LIBSOURCES:.c=.o) $(DERSOURCES:.c=.o) $(VFSSOURCES:.c=.o)
 CCOBJECTS = $(addsuffix .o,$(basename $(CCSOURCES)))
 
 ifdef CORECRYPTO
@@ -100,6 +106,7 @@ CC = clang
 CFLAGS += -Wno-gnu -DUSE_CORECRYPTO #-DIBOOT=1
 #CFLAGS += -DNO_CCZP_OPTIONS	# either way
 OBJECTS += $(CCOBJECTS)
+LIBOBJECTS += $(CCOBJECTS)
 else
 ifdef COMMONCRYPTO
 CC = clang
@@ -121,8 +128,11 @@ all: img4
 img4: $(OBJECTS)
 	$(LD) -o $@ $(LDFLAGS) $^ $(LDLIBS)
 
+libimg4.a: $(LIBOBJECTS)
+	$(LIBTOOL) $(LIBTOOL_FLAGS) -o $@ $^
+
 clean:
-	-$(RM) $(OBJECTS) $(CCOBJECTS)
+	-$(RM) $(OBJECTS) $(LIBOBJECTS) $(CCOBJECTS)
 
 distclean: clean
-	-$(RM) img4
+	-$(RM) img4 libimg4.a

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CFLAGS += -O2 -I. -g -DiOS10 -Ilzfse/src
 CFLAGS += -DDER_MULTIBYTE_TAGS=1 -DDER_TAG_SIZE=8
 CFLAGS += -D__unused="__attribute__((unused))"
 
-LD ?= gcc
+LD = gcc
 LDFLAGS = -g -Llzfse/build/bin
 LDLIBS = -llzfse
 
@@ -101,21 +101,28 @@ LIBOBJECTS = $(LIBSOURCES:.c=.o) $(DERSOURCES:.c=.o) $(VFSSOURCES:.c=.o)
 CCOBJECTS = $(addsuffix .o,$(basename $(CCSOURCES)))
 
 ifdef CORECRYPTO
-CC ?= clang
+CC = clang
 CFLAGS += -Wno-gnu -DUSE_CORECRYPTO #-DIBOOT=1
 #CFLAGS += -DNO_CCZP_OPTIONS	# either way
 OBJECTS += $(CCOBJECTS)
 LIBOBJECTS += $(CCOBJECTS)
 else
 ifdef COMMONCRYPTO
-CC ?= clang
+CC = clang
 CFLAGS += -DUSE_COMMONCRYPTO=1
 LDLIBS += -framework Security -framework CoreFoundation
 else
-CC ?= gcc
+CC = gcc
 CFLAGS += -Wno-deprecated-declarations
 LDLIBS += -lcrypto
 endif
+endif
+
+ifdef OVERRIDE_LD
+LD = $(OVERRIDE_LD)
+endif
+ifdef OVERRIDE_CC
+CC = $(OVERRIDE_CC)
 endif
 
 export CC

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ Some WIP code to deal with img4 files in a decent manner.
 
 Build:
 
-git submodule init && git submodule update && make -C lzfse && make
+git submodule init && git submodule update && make
 
 Examples:
 


### PR DESCRIPTION
- Create gitignore to ignore object files
- Make liblzfse an actual dependency in the Makefile
- Add Makefile targets for building as static library
- Add `OVERRIDE_CC` and `OVERRIDE_LD` env vars to allow for cross-compiling