### PR TITLE
add an interface to get Der tag values

### DIFF
--- a/libvfs/vfs.h
+++ b/libvfs/vfs.h
@@ -38,6 +38,9 @@ struct file_ops {
 #define IOCTL_IMG4_SET_VERSION  71	/* (void *, size_t) */
 #define IOCTL_IMG4_EVAL_TRUST   90	/* (void *) */
 
+// Custom additions
+#define IOCTL_IMG4_GET_PROPERTY 1000	/* (char *, void *, size_t) */
+
 #define FLAG_IMG4_SKIP_DECOMPRESSION    (1 << 0)
 #define FLAG_IMG4_VERIFY_HASH           (1 << 1)
 


### PR DESCRIPTION
This addition adds a universal interface to query tag values.
It is easily possible to avoid code duplication, however, I tried to keep the base implementation as close as possible to the original.